### PR TITLE
Add HTTP QUERY stage 1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Validate composer.json
-        run: composer validate --strict
+        run: composer validate --strict --no-check-version
 
       - name: Run PHPStan
         run: composer cs || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['8.1', '8.2', '8.3']
 
     name: PHP ${{ matrix.php-version }}
 
@@ -47,6 +47,9 @@ jobs:
       - name: Run PHPUnit
         run: vendor/bin/phpunit --testsuite "SimpleRest Tests" --no-coverage --log-junit reports/junit.xml
         continue-on-error: true
+
+      - name: Run HTTP QUERY tests
+        run: composer test:http-query
 
       - name: Upload test results
         if: always()

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
             "php-http/discovery": true
         }
     },
+    "scripts": {
+        "test:http-query": "@php vendor/bin/phpunit -c phpunit-http-query.xml"
+    },
     "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc8c808d31ca3cfd8c5a59b3097d97f6",
+    "content-hash": "437cdf8c2ab64678a0b32868fd4e3a1c",
     "packages": [
         {
             "name": "graham-campbell/result-type",

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowedHeaders' => ['*'],
 
-    'exposedHeaders' => [],
+    'exposedHeaders' => ['Accept-Query'],
 
     'maxAge' => 0,
 

--- a/docs/ApiClient.md
+++ b/docs/ApiClient.md
@@ -26,7 +26,13 @@ Ej: (base)
         return;
     }
 
-Para utilizar POST es con post() en vez de get() y soporta tambien delete(), patch() y put()
+Para utilizar POST es con post() en vez de get() y soporta tambien delete(), patch(), put() y query().
+
+```php
+$client
+    ->setHeaders(['Content-Type' => 'application/json'])
+    ->query($url, ['status' => 'active']);
+```
 
 también se pueden incluir headers.
 

--- a/docs/Routing.md
+++ b/docs/Routing.md
@@ -62,7 +62,7 @@ SimpleRest Framework ofrece un sistema de routing flexible que soporta tanto rut
 
 ### Componentes principales:
 
-- **WebRouter**: Maneja rutas HTTP con soporte para verbos GET, POST, PUT, PATCH, DELETE, OPTIONS
+- **WebRouter**: Maneja rutas HTTP con soporte para verbos GET, POST, PUT, PATCH, DELETE, OPTIONS y QUERY
 - **CliRouter**: Maneja comandos de consola con soporte para comandos simples y multi-palabra
 - **FrontController**: Sistema simplificado principalmente para uso en terminal
 
@@ -119,6 +119,7 @@ WebRouter::get('/usuario/{id}', 'UserController@show');
 WebRouter::post('/producto', 'ProductController@store');
 WebRouter::put('/producto/{id}', 'ProductController@update');
 WebRouter::delete('/producto/{id}', 'ProductController@destroy');
+WebRouter::query('/producto/search', 'ProductController@search');
 ```
 
 #### Usando `fromArray()`
@@ -129,6 +130,7 @@ Permite definir múltiples rutas en un solo llamado:
 WebRouter::fromArray([
     'GET:/speed_check' => 'SpeedCheckController@index',
     'POST:/producto' => 'ProductController@store',
+    'QUERY:/producto/search' => 'ProductController@search',
     '/ping' => 'SystemController@ping' // Todos los verbos
 ]);
 ```

--- a/docs/WebRouter.md
+++ b/docs/WebRouter.md
@@ -13,8 +13,29 @@ WebRouter::put('uri', 'Controller@method');
 WebRouter::patch('uri', 'Controller@method');
 WebRouter::delete('uri', 'Controller@method');
 WebRouter::options('uri', 'Controller@method');
+WebRouter::query('uri', 'Controller@method');
 WebRouter::any('uri', 'Controller@method');
 ```
+
+### HTTP QUERY
+
+`QUERY` is a safe and idempotent method with request content, as defined by RFC 10008. The initial SimpleRest implementation accepts JSON content:
+
+```php
+WebRouter::query('products/search', function () {
+    return Product::search(request()->getBody(false));
+});
+```
+
+```http
+QUERY /products/search HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+{"status":"active"}
+```
+
+Use the uppercase method name in browser `fetch()` calls. Cross-origin requests use a CORS preflight; SimpleRest handles that preflight before WebRouter dispatch.
 
 ## Advanced Features
 
@@ -24,8 +45,10 @@ The `any` method registers a route that responds to all HTTP verbs:
 
 ```php
 WebRouter::any('uri', 'Controller@method');
-// This route will respond to GET, POST, PUT, PATCH, DELETE, and OPTIONS requests
+// Responds to GET, POST, PUT, PATCH, DELETE, OPTIONS, and QUERY requests
 ```
+
+Callbacks registered with `any()` must remain safe and idempotent when invoked through QUERY.
 
 ### Soporte de wildcards
 
@@ -140,6 +163,7 @@ Define multiple routes from an array:
 WebRouter::fromArray([
     'GET:/users' => 'UserController@index',
     'POST:/users' => 'UserController@store',
+    'QUERY:/users/search' => 'UserController@search',
     'GET:/posts' => 'PostController@index',
 ]);
 ```

--- a/docs/_internal/to-do/http-query-support.md
+++ b/docs/_internal/to-do/http-query-support.md
@@ -1,0 +1,108 @@
+# HTTP QUERY support plan
+
+## Objective
+
+Add incremental support for RFC 10008 without changing the behavior of existing GET, POST, PUT, PATCH, DELETE, or OPTIONS endpoints.
+
+The first release supports JSON QUERY requests on explicit WebRouter routes. Automatic ApiController resources are intentionally deferred until their read pipeline can consume URI and body criteria without duplicating the existing `get()` implementation.
+
+## Stage 1 — WebRouter and transport support
+
+Status: implemented on the task branch.
+
+- [x] Add `WebRouter::query()`.
+- [x] Centralize route registration and fix the missing current URI assignment in `WebRouter::put()`.
+- [x] Include QUERY in `match()`, `any()`, and `fromArray()`.
+- [x] Normalize custom methods to uppercase.
+- [x] Normalize request header names case-insensitively.
+- [x] Accept media type parameters such as `application/json; charset=utf-8`.
+- [x] Parse JSON bodies for every HTTP method, including QUERY.
+- [x] Validate QUERY Content-Type, body presence, and JSON container type.
+- [x] Add QUERY and HEAD to the CORS wildcard expansion.
+- [x] Handle CORS before WebRouter dispatch so QUERY preflights do not require an explicit OPTIONS route.
+- [x] Normalize leading slashes when matching configured CORS paths.
+- [x] Expose `Accept-Query` through the default CORS configuration.
+- [x] Add QUERY support to ApiClient.
+- [x] Fix the individual ACL callable bugs for POST and PATCH.
+- [x] Add focused PHPUnit coverage and a Node.js live smoke test.
+- [x] Run the focused PHPUnit suite in CI on PHP 8.1, 8.2, and 8.3.
+
+### Stage 1 contract
+
+```php
+WebRouter::query('products/search', function () {
+    return Product::search(request()->getBody(false));
+});
+```
+
+```http
+QUERY /products/search HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+{"status":"active"}
+```
+
+Stage 1 accepts `application/json` only. Missing Content-Type or body returns 400, unsupported media types return 415, malformed JSON returns 400, and scalar JSON query content returns 422.
+
+`any()` routes now include QUERY. Applications upgrading SimpleRest must verify that callbacks registered with `any()` remain safe and idempotent when invoked through QUERY.
+
+## Stage 2 — Automatic ApiController endpoints
+
+- [ ] Add `query()` to the IApi contract and ApiController.
+- [ ] Map QUERY to the same `read_all`, `list`, `list_all`, `show`, and `show_all` permissions as GET.
+- [ ] Extract the current `ApiController::get()` read pipeline into one reusable internal operation.
+- [ ] Keep URI parameters and query content separate in Request.
+- [ ] Create adapters for the existing URI query DSL and its JSON body representation.
+- [ ] Enable QUERY first for collection endpoints such as `/api/v1/products`.
+- [ ] Compare GET and QUERY results for the same filters, ordering, projection, pagination, and tenant scope.
+- [ ] Add regression tests for role permissions and individual ACL bitmasks.
+
+The first automatic JSON representation should preserve the existing SimpleRest query DSL:
+
+```json
+{
+  "fields": "id,name,cost",
+  "cost": {"between": "49,100"},
+  "order": {"cost": "ASC"},
+  "page": 1,
+  "pageSize": 50
+}
+```
+
+## Stage 3 — RFC discovery and advanced HTTP behavior
+
+- [ ] Add route-specific accepted query media types.
+- [ ] Emit `Accept-Query` on OPTIONS and applicable resource responses.
+- [ ] Emit accurate `Allow` headers on 405 responses.
+- [ ] Add `Location` and `Content-Location` support for equivalent resources.
+- [ ] Add ETag and conditional QUERY coverage.
+- [ ] Evaluate cache keys that include query content and relevant metadata.
+- [ ] Test redirects, retries, reverse proxies, WAFs, Cloudflare, Apache, Nginx, and PHP-FPM.
+- [ ] Document OpenAPI representation while native QUERY support remains ecosystem-dependent.
+
+## Verification
+
+Focused unit suite:
+
+```bash
+composer test:http-query
+```
+
+Live transport smoke test against any explicit QUERY route:
+
+```bash
+npm run test:http-query:smoke -- http://simplerest.lan/products/search
+```
+
+Equivalent curl check:
+
+```bash
+curl -i -X QUERY \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  --data '{"status":"active"}' \
+  http://simplerest.lan/products/search
+```
+
+For cross-origin browser tests, verify that the OPTIONS response includes QUERY in `Access-Control-Allow-Methods` before checking the actual QUERY request in DevTools.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test:http-query:smoke": "node unit-tests/http-query/http-query-smoke.mjs"
+  },
   "dependencies": {
     "moment-timezone": "^0.5.43"
   },

--- a/phpunit-http-query.xml
+++ b/phpunit-http-query.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         failOnEmptyTestSuite="true"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="HTTP QUERY support">
+            <directory>unit-tests/http-query</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/framework/Api/ApiController.php
+++ b/src/framework/Api/ApiController.php
@@ -205,7 +205,7 @@ abstract class ApiController extends ResourceController implements IApi, ISubRes
                 
                 case 'POST': 
                     if (($perms & 4 ) AND 1){
-                        $this->addCallable('get');
+                        $this->addCallable('post');
                     }
                 break;    
 
@@ -217,7 +217,7 @@ abstract class ApiController extends ResourceController implements IApi, ISubRes
                       
                 case 'PATCH':
                     if (($perms & 2 ) AND 1){
-                        $this->addCallable('putch');
+                        $this->addCallable('patch');
                     }                      
                 break;    
 
@@ -2599,4 +2599,4 @@ abstract class ApiController extends ResourceController implements IApi, ISubRes
     protected function onPutFolder($id, Array $data, ?int $affected, $folder){ }
 
     
-}  
+}

--- a/src/framework/Libs/ApiClient.php
+++ b/src/framework/Libs/ApiClient.php
@@ -45,6 +45,7 @@ class ApiClient
     const HTTP_METH_PUT    = "PUT";
     const HTTP_METH_DELETE = "DELETE";
     const HTTP_METH_HEAD   = "HEAD";
+    const HTTP_METH_QUERY  = "QUERY";
 
     /*
         User Agents
@@ -981,10 +982,24 @@ class ApiClient
         return $this->request($url, 'PATCH', $body, $headers, $options);
     }
 
+    function query($url = null, $body = null, $headers = null, $options = null){
+        if (!empty($this->base_url) && $url !== null && $url[0] === '/') {
+            $url = $this->base_url . $url;
+        } else {
+            $url = $this->url ?? $url;
+        }
+
+        if ($url === null){
+            throw new \InvalidArgumentException("Param url is needed. Set in " . __METHOD__ . " or constructor or setUrl()");
+        }
+
+        return $this->request($url, 'QUERY', $body, $headers, $options);
+    }
+
     function setMethod(string $verb){
         $verb = strtoupper($verb);
         
-        if (!in_array($verb, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])){
+        if (!in_array($verb, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'])){
             throw new \InvalidArgumentException("Unsupported verb \"$verb\"");
         }
 
@@ -1254,5 +1269,4 @@ class ApiClient
 		return function_exists('curl_init');
 	}
 }
-
 

--- a/src/framework/Libs/CorsHandler.php
+++ b/src/framework/Libs/CorsHandler.php
@@ -14,6 +14,17 @@ namespace Boctulus\Simplerest\Core\Libs;
 */
 class CorsHandler 
 {
+    public const DEFAULT_METHODS = [
+        'GET',
+        'HEAD',
+        'POST',
+        'PUT',
+        'PATCH',
+        'DELETE',
+        'OPTIONS',
+        'QUERY',
+    ];
+
     private array $paths;
     private array $allowedOrigins;
     private bool  $supportsCredentials;
@@ -37,9 +48,7 @@ class CorsHandler
         
         $this->paths = $paths;
         $this->allowedOrigins = $allowedOrigins;
-        $this->allowedMethods = $this->parseWildcard($allowedMethods, [
-            'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'
-        ]);
+        $this->allowedMethods = $this->parseWildcard($allowedMethods, static::DEFAULT_METHODS);
         $this->allowedHeaders = $this->parseWildcard($allowedHeaders);
         $this->exposedHeaders = $exposedHeaders;
         $this->allowedOriginsPatterns = $allowedOriginsPatterns;
@@ -52,7 +61,11 @@ class CorsHandler
             return;
         }
 
-        $origin = $_SERVER['HTTP_ORIGIN'] ?? ($_SERVER['HTTP_REFERER'] ?? '');
+        $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+
+        if ($origin === '') {
+            return;
+        }
 
         if ($this->isOriginAllowed($origin)) {
             $this->setCorsHeaders($origin);
@@ -101,9 +114,7 @@ class CorsHandler
     }
 
     public function setAllowedMethods(array $methods): void {
-        $this->allowedMethods = $this->parseWildcard($methods, [
-            'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'
-        ]);
+        $this->allowedMethods = $this->parseWildcard($methods, static::DEFAULT_METHODS);
     }
 
     public function setAllowedOriginsPatterns(array $patterns): void {
@@ -119,10 +130,13 @@ class CorsHandler
     }
 
     private function isPathAllowed(): bool {
-        $requestPath = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH) ?? '/';        
+        $requestPath = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH) ?? '/';
+        $requestPath = ltrim($requestPath, '/');
         
         foreach ($this->paths as $pattern) {
-            if ($pattern === '*' || fnmatch($pattern, $requestPath)) {
+            $normalizedPattern = ltrim($pattern, '/');
+
+            if ($pattern === '*' || fnmatch($normalizedPattern, $requestPath)) {
                 return true;
             }
         }

--- a/src/framework/Request.php
+++ b/src/framework/Request.php
@@ -19,6 +19,7 @@ class Request  implements \ArrayAccess, Arrayable
     protected static $query_arr;
     protected static $raw;
     protected static $body;
+    protected static $body_error;
     protected static $params;
     protected static $headers;
     protected static $accept_encoding;
@@ -34,19 +35,57 @@ class Request  implements \ArrayAccess, Arrayable
         return $this;
     }
 
-    static function getHeaders() {
-        if (function_exists('apache_request_headers')) {
-            return apache_request_headers();
+    public static function normalizeHeaders(array $headers): array {
+        $normalized = [];
+
+        foreach ($headers as $key => $value) {
+            $normalized[strtolower($key)] = $value;
         }
-        // alternativa para obtener los encabezados en otros servidores
-        $headers = [];
-        foreach ($_SERVER as $key => $value) {
-            if (strpos($key, 'HTTP_') === 0) {
-                $header = str_replace('_', '-', strtolower(substr($key, 5)));
-                $headers[$header] = $value;
+
+        return $normalized;
+    }
+
+    public static function getHeaders(): array {
+        if (function_exists('apache_request_headers')) {
+            $headers = (array) apache_request_headers();
+        } else {
+            $headers = [];
+
+            foreach ($_SERVER as $key => $value) {
+                if (strpos($key, 'HTTP_') === 0) {
+                    $header = str_replace('_', '-', substr($key, 5));
+                    $headers[$header] = $value;
+                }
             }
         }
-        return $headers;
+
+        if (isset($_SERVER['CONTENT_TYPE'])) {
+            $headers['Content-Type'] = $_SERVER['CONTENT_TYPE'];
+        }
+
+        if (isset($_SERVER['CONTENT_LENGTH'])) {
+            $headers['Content-Length'] = $_SERVER['CONTENT_LENGTH'];
+        }
+
+        return static::normalizeHeaders($headers);
+    }
+
+    public static function extractMediaType(?string $contentType): ?string {
+        if ($contentType === null) {
+            return null;
+        }
+
+        $mediaType = strtolower(trim(explode(';', $contentType, 2)[0]));
+        return $mediaType === '' ? null : $mediaType;
+    }
+
+    public static function normalizeMethod(?string $method): ?string {
+        if ($method === null) {
+            return null;
+        }
+
+        $method = trim($method);
+        return $method === '' ? null : strtoupper($method);
     }
 
     static function isBrowser(): bool 
@@ -68,6 +107,8 @@ class Request  implements \ArrayAccess, Arrayable
     static function getInstance() : Request {
         if(static::$instance == NULL){
             if (php_sapi_name() != 'cli'){
+                static::$query_arr = [];
+
                 if (isset($_SERVER['QUERY_STRING'])){
                     static::$query_arr = url::queryString();
                 }
@@ -87,13 +128,15 @@ class Request  implements \ArrayAccess, Arrayable
 
                 $headers = static::getHeaders();
 
-                $accept_encoding_header = $headers['Accept-Encoding'] ?? null;
+                static::$headers = $headers;
+
+                $accept_encoding_header = $headers['accept-encoding'] ?? null;
                 
                 if (!empty($accept_encoding_header)){
                     static::$accept_encoding = $accept_encoding_header;
                 } else {
                     if (!empty(static::$query_arr["accept_encoding"])){
-                        static::$accept_encoding = Arrays::shift(static::$accept_encoding, 'accept_encoding');
+                        static::$accept_encoding = Arrays::shift(static::$query_arr, 'accept_encoding');
                     }
                 }                
                 
@@ -104,34 +147,37 @@ class Request  implements \ArrayAccess, Arrayable
                     'multipart/form-data; boundary=--------------------------240766805501822956475464'
                 */
 
-                $content_type_header = $headers['Content-Type'] ?? null;
+                $content_type_header = $headers['content-type'] ?? null;
 
                 if (!empty($content_type_header)){
                     static::$content_type = $content_type_header;
                     
                 } else {
                     if (!empty(static::$query_arr["content_type"])){
-                        static::$content_type = Arrays::shift(static::$accept_encoding, 'content_type');
+                        static::$content_type = Arrays::shift(static::$query_arr, 'content_type');
                     }
                 }   
 
                 // Content-Type
-                $is_form_data = (bool) Strings::startsWith('multipart/form-data', static::$content_type);
-                $is_json      = (static::$content_type == 'application/json');
+                $media_type   = static::extractMediaType(static::$content_type);
+                $is_form_data = ($media_type === 'multipart/form-data');
+                $is_json      = ($media_type === 'application/json');
 
                 static::$raw  = file_get_contents("php://input");
 
                 // Si el Content-Type es para json,.... decode
 
-                static::$body = ($is_json && !empty(static::$raw)) ? Url::bodyDecode(static::$raw) : static::$raw;
-                
-                static::$headers = apache_request_headers();
+                static::$body = static::$raw;
+                static::$body_error = null;
 
-                $tmp = [];
-                foreach (static::$headers as $key => $val){
-                    $tmp[strtolower($key)] = $val;
+                if ($is_json && static::$raw !== '') {
+                    static::$body = json_decode(static::$raw, true);
+
+                    if (json_last_error() !== JSON_ERROR_NONE) {
+                        static::$body = null;
+                        static::$body_error = 'Invalid JSON body: ' . json_last_error_msg();
+                    }
                 }
-                static::$headers = $tmp;
                 
             }
             static::$instance = new static();
@@ -212,6 +258,62 @@ class Request  implements \ArrayAccess, Arrayable
     // alias
     function getHeader(string $key){
         return $this->header($key);
+    }
+
+    public function getContentType(): ?string {
+        return static::$content_type;
+    }
+
+    public function getMediaType(): ?string {
+        return static::extractMediaType(static::$content_type);
+    }
+
+    public function hasBody(): bool {
+        return static::$raw !== null && static::$raw !== '';
+    }
+
+    public function getBodyError(): ?string {
+        return static::$body_error;
+    }
+
+    public function validateQueryRequest(array $supportedMediaTypes = ['application/json']): void {
+        if ($this->method() !== 'QUERY') {
+            return;
+        }
+
+        $mediaType = $this->getMediaType();
+
+        if ($mediaType === null) {
+            throw new \InvalidArgumentException(
+                'Content-Type is required for QUERY requests',
+                400
+            );
+        }
+
+        if (!in_array($mediaType, $supportedMediaTypes, true)) {
+            throw new \InvalidArgumentException(
+                "Unsupported Content-Type for QUERY requests: {$mediaType}",
+                415
+            );
+        }
+
+        if (!$this->hasBody()) {
+            throw new \InvalidArgumentException(
+                'QUERY requests require a request body',
+                400
+            );
+        }
+
+        if (static::$body_error !== null) {
+            throw new \InvalidArgumentException(static::$body_error, 400);
+        }
+
+        if ($mediaType === 'application/json' && !is_array(static::$body)) {
+            throw new \InvalidArgumentException(
+                'QUERY JSON content must be an object or array',
+                422
+            );
+        }
     }
 
     function shiftHeader(string $key){
@@ -453,7 +555,7 @@ class Request  implements \ArrayAccess, Arrayable
             $asked_method = $_SERVER['REQUEST_METHOD'] ?? NULL;
         }
         
-        return $asked_method;
+        return static::normalizeMethod($asked_method);
     }
 
     static function ip(){

--- a/src/framework/WebRouter.php
+++ b/src/framework/WebRouter.php
@@ -20,6 +20,16 @@ use Boctulus\Simplerest\Core\Libs\Url;
 
 class WebRouter
 {
+    public const SUPPORTED_METHODS = [
+        'GET',
+        'POST',
+        'PUT',
+        'PATCH',
+        'DELETE',
+        'OPTIONS',
+        'QUERY',
+    ];
+
     protected static $routes       = [];
     protected static $params;
     protected static $current      = [];
@@ -106,14 +116,28 @@ class WebRouter
         $path = preg_replace('/(.*)\/index.php/', '/', $path);
         $path = trim($path, '/');
                 
-        $req_method = $_SERVER['REQUEST_METHOD'] ?? NULL;
+        $request = Request::getInstance();
+        $req_method = $request->method();
         
         if ($req_method == NULL){
             // CLI o metodo non definito
         }
 
+        cors();
+
         if (!isset(static::$routes[$req_method])){
             return;
+        }
+
+        if ($req_method === 'QUERY') {
+            try {
+                $request->validateQueryRequest();
+            } catch (\InvalidArgumentException $exception) {
+                Response::getInstance()->error(
+                    $exception->getMessage(),
+                    $exception->getCode() ?: 400
+                );
+            }
         }
 
         $res = Response::getInstance(); 
@@ -481,111 +505,62 @@ class WebRouter
         return static::getInstance();
     }
 
-    // Modifica nei metodi di registrazione per gestire il prefisso di gruppo
-    public static function get(string $uri, $callback){
+    protected static function register(string $method, string $uri, $callback){
+        $method = Request::normalizeMethod($method);
         $uri = Strings::rTrim('/', $uri);
+
         if(static::$groupPrefix !== ''){
             $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
         }
-        static::$current_verb = 'GET';
+
+        static::$current_verb = $method;
         static::$current_uri = $uri;
-        static::$current = ['GET', $uri];
-        static::$routes['GET'][$uri] = $callback;
+        static::$current = [$method, $uri];
+        static::$routes[$method][$uri] = $callback;
+
         return static::getInstance();
+    }
+
+    // Modifica nei metodi di registrazione per gestire il prefisso di gruppo
+    public static function get(string $uri, $callback){
+        return static::register('GET', $uri, $callback);
     }
 
     public static function post(string $uri, $callback){
-        $uri = Strings::rTrim('/', $uri);
-        if(static::$groupPrefix !== ''){
-            $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
-        }
-        static::$current_verb = 'POST';
-        static::$current_uri = $uri;
-        static::$current = ['POST', $uri];
-        static::$routes['POST'][$uri] = $callback;
-        return static::getInstance();
+        return static::register('POST', $uri, $callback);
     }
 
     public static function put(string $uri, $callback){
-        $uri = Strings::rTrim('/', $uri);
-        if(static::$groupPrefix !== ''){
-            $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
-        }
-        static::$current_verb = 'PUT';
-        static::$current = ['PUT', $uri];
-        static::$routes['PUT'][$uri] = $callback;
-        return static::getInstance();
+        return static::register('PUT', $uri, $callback);
     }
 
     public static function patch(string $uri, $callback){
-        $uri = Strings::rTrim('/', $uri);
-        if(static::$groupPrefix !== ''){
-            $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
-        }
-        static::$current_verb = 'PATCH';
-        static::$current_uri = $uri;
-        static::$current = ['PATCH', $uri];
-        static::$routes['PATCH'][$uri] = $callback;
-        return static::getInstance();
+        return static::register('PATCH', $uri, $callback);
     }
 
     public static function delete(string $uri, $callback){
-        $uri = Strings::rTrim('/', $uri);
-        if(static::$groupPrefix !== ''){
-            $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
-        }
-        static::$current_verb = 'DELETE';
-        static::$current_uri = $uri;
-        static::$current = ['DELETE', $uri];
-        static::$routes['DELETE'][$uri] = $callback;
-        return static::getInstance();
+        return static::register('DELETE', $uri, $callback);
     }
     
     public static function options(string $uri, $callback){
-        $uri = Strings::rTrim('/', $uri);
-        if(static::$groupPrefix !== ''){
-            $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
-        }
-        static::$current_verb = 'OPTIONS';
-        static::$current_uri = $uri;
-        static::$current = ['OPTIONS', $uri];
-        static::$routes['OPTIONS'][$uri] = $callback;
-        return static::getInstance();
+        return static::register('OPTIONS', $uri, $callback);
+    }
+
+    public static function query(string $uri, $callback){
+        return static::register('QUERY', $uri, $callback);
     }
 
     public static function any(string $uri, $callback){
-        $uri = Strings::rTrim('/', $uri);
-
-        if(static::$groupPrefix !== ''){
-            $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
-        }
-
-        $verbs = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
-
-        foreach ($verbs as $verb){
-            static::$current_verb = $verb;
-            static::$current_uri  = $uri;
-            static::$current      = [$verb, $uri];
-            static::$routes[$verb][$uri] = $callback;
+        foreach (static::SUPPORTED_METHODS as $method){
+            static::register($method, $uri, $callback);
         }
 
         return static::getInstance();
     }
 
     public static function match(array $verbs, string $uri, $callback){
-        $uri = Strings::rTrim('/', $uri);
-
-        if(static::$groupPrefix !== ''){
-            $uri = trim(static::$groupPrefix, '/') . '/' . ltrim($uri, '/');
-        }
-
-        $verbs = array_map('strtoupper', $verbs);
-
-        foreach ($verbs as $verb){
-            static::$current_verb = $verb;
-            static::$current_uri  = $uri;
-            static::$current      = [$verb, $uri];
-            static::$routes[$verb][$uri] = $callback;
+        foreach ($verbs as $method){
+            static::register($method, $uri, $callback);
         }
 
         return static::getInstance();
@@ -609,7 +584,7 @@ class WebRouter
 
     public static function fromArray(array $routes) {
         // Definizione dei verbi HTTP supportati
-        $supportedVerbs = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+        $supportedVerbs = static::SUPPORTED_METHODS;
 
         foreach ($routes as $routeKey => $callback) {
             // Se il formato della chiave contiene ":", significa che è specificato un verbo
@@ -620,37 +595,18 @@ class WebRouter
 
                 // Se il verbo è supportato, chiama il metodo di registrazione corrispondente
                 if (in_array($verb, $supportedVerbs)) {
-                    switch ($verb) {
-                        case 'GET':
-                            self::get($uri, $callback);
-                            break;
-                        case 'POST':
-                            self::post($uri, $callback);
-                            break;
-                        case 'PUT':
-                            self::put($uri, $callback);
-                            break;
-                        case 'PATCH':
-                            self::patch($uri, $callback);
-                            break;
-                        case 'DELETE':
-                            self::delete($uri, $callback);
-                            break;
-                        case 'OPTIONS':
-                            self::options($uri, $callback);
-                            break;
-                    }
+                    static::register($verb, $uri, $callback);
                 } else {
                     // Se il verbo specificato non è riconosciuto, registra per tutti i verbi supportati
                     foreach ($supportedVerbs as $v) {
-                        call_user_func([__CLASS__, strtolower($v)], $uri, $callback);
+                        static::register($v, $uri, $callback);
                     }
                 }
             } else {
                 // Se non viene specificato alcun verbo, registra la rotta per tutti i verbi supportati
                 $uri = trim($routeKey, '/');
                 foreach ($supportedVerbs as $v) {
-                    call_user_func([__CLASS__, strtolower($v)], $uri, $callback);
+                    static::register($v, $uri, $callback);
                 }
             }
         }

--- a/unit-tests/http-query/HttpQuerySupportTest.php
+++ b/unit-tests/http-query/HttpQuerySupportTest.php
@@ -1,0 +1,242 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Boctulus\Simplerest\Core\Libs\ApiClient;
+use Boctulus\Simplerest\Core\Libs\Config;
+use Boctulus\Simplerest\Core\Libs\CorsHandler;
+use Boctulus\Simplerest\Core\Request;
+use Boctulus\Simplerest\Core\WebRouter;
+
+require_once __DIR__ . '/../../config/constants.php';
+
+final class HttpQuerySupportTest extends TestCase
+{
+    private array $serverBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->serverBackup = $_SERVER;
+        $this->resetRouter();
+        $this->resetRequest();
+        $this->setStaticProperty(Config::class, 'data', [
+            'method_override' => [
+                'by_url' => false,
+                'by_header' => false,
+            ],
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->serverBackup;
+        parent::tearDown();
+    }
+
+    public function testQueryRouteCanBeRegistered(): void
+    {
+        WebRouter::query('products/search', static fn () => ['ok' => true]);
+
+        $routes = WebRouter::getRoutes();
+
+        $this->assertArrayHasKey('QUERY', $routes);
+        $this->assertArrayHasKey('products/search', $routes['QUERY']);
+    }
+
+    public function testAnyAndFromArrayIncludeQuery(): void
+    {
+        WebRouter::any('health', static fn () => ['ok' => true]);
+        WebRouter::fromArray([
+            'QUERY:reports/search' => static fn () => ['ok' => true],
+        ]);
+
+        $routes = WebRouter::getRoutes();
+
+        $this->assertArrayHasKey('health', $routes['QUERY']);
+        $this->assertArrayHasKey('reports/search', $routes['QUERY']);
+    }
+
+    public function testPutRouteKeepsCurrentUriForNaming(): void
+    {
+        WebRouter::put('products/{id}', static fn () => ['ok' => true])
+            ->name('products.update');
+
+        $aliases = $this->getStaticProperty(WebRouter::class, 'aliases');
+
+        $this->assertSame('PUT', $aliases['products.update']['verb']);
+        $this->assertSame('products/{id}', $aliases['products.update']['uri']);
+    }
+
+    public function testRequestNormalizesMethodsHeadersAndMediaTypes(): void
+    {
+        $headers = Request::normalizeHeaders([
+            'Content-Type' => 'Application/JSON; Charset=UTF-8',
+            'X-Request-ID' => 'query-test',
+        ]);
+
+        $this->assertSame('QUERY', Request::normalizeMethod('query'));
+        $this->assertSame('Application/JSON; Charset=UTF-8', $headers['content-type']);
+        $this->assertSame('query-test', $headers['x-request-id']);
+        $this->assertSame(
+            'application/json',
+            Request::extractMediaType($headers['content-type'])
+        );
+    }
+
+    public function testValidQueryRequestAcceptsJsonWithCharset(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+        $this->setStaticProperty(Request::class, 'content_type', 'application/json; charset=utf-8');
+        $this->setStaticProperty(Request::class, 'raw', '{"status":"active"}');
+        $this->setStaticProperty(Request::class, 'body', ['status' => 'active']);
+
+        Request::getInstance()->validateQueryRequest();
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @dataProvider invalidQueryRequestProvider
+     */
+    public function testInvalidQueryRequestReturnsExpectedStatus(
+        ?string $contentType,
+        string $raw,
+        $body,
+        ?string $bodyError,
+        int $expectedStatus
+    ): void {
+        $_SERVER['REQUEST_METHOD'] = 'QUERY';
+        $this->setStaticProperty(Request::class, 'content_type', $contentType);
+        $this->setStaticProperty(Request::class, 'raw', $raw);
+        $this->setStaticProperty(Request::class, 'body', $body);
+        $this->setStaticProperty(Request::class, 'body_error', $bodyError);
+
+        try {
+            Request::getInstance()->validateQueryRequest();
+            $this->fail('Expected QUERY request validation to fail');
+        } catch (\InvalidArgumentException $exception) {
+            $this->assertSame($expectedStatus, $exception->getCode());
+        }
+    }
+
+    public static function invalidQueryRequestProvider(): array
+    {
+        return [
+            'missing content type' => [null, '{"status":"active"}', ['status' => 'active'], null, 400],
+            'unsupported media type' => ['text/plain', 'status=active', 'status=active', null, 415],
+            'missing body' => ['application/json', '', null, null, 400],
+            'malformed JSON' => ['application/json', '{', null, 'Invalid JSON body: Syntax error', 400],
+            'scalar JSON content' => ['application/json', '"active"', 'active', null, 422],
+        ];
+    }
+
+    public function testCorsWildcardIncludesQuery(): void
+    {
+        $handler = new CorsHandler();
+        $allowedMethods = $this->getProperty($handler, 'allowedMethods');
+
+        $this->assertContains('QUERY', $allowedMethods);
+        $this->assertContains('HEAD', $allowedMethods);
+    }
+
+    public function testCorsPathMatchesLeadingSlashRequestUri(): void
+    {
+        $_SERVER['REQUEST_URI'] = '/api/v1/products';
+        $handler = new CorsHandler(['api/*']);
+
+        $reflection = new ReflectionClass($handler);
+        $method = $reflection->getMethod('isPathAllowed');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($handler));
+    }
+
+    public function testApiClientAcceptsQueryMethod(): void
+    {
+        $reflection = new ReflectionClass(ApiClient::class);
+        $client = $reflection->newInstanceWithoutConstructor();
+
+        $client->setMethod('query');
+
+        $this->assertSame('QUERY', $this->getProperty($client, 'verb'));
+        $this->assertSame('QUERY', ApiClient::HTTP_METH_QUERY);
+    }
+
+    private function resetRouter(): void
+    {
+        $reflection = new ReflectionClass(WebRouter::class);
+
+        foreach ([
+            'routes' => [],
+            'params' => [],
+            'current' => [],
+            'wheres' => [],
+            'ck_params' => [],
+            'ctrls' => [],
+            'current_verb' => null,
+            'current_uri' => null,
+            'aliases' => [],
+            'v_aliases' => [],
+            'routePatterns' => [],
+            'routeParamNames' => [],
+            'groupPrefix' => '',
+        ] as $property => $value) {
+            $this->setStaticProperty(WebRouter::class, $property, $value);
+        }
+
+        $this->setStaticProperty(
+            WebRouter::class,
+            'instance',
+            $reflection->newInstanceWithoutConstructor()
+        );
+    }
+
+    private function resetRequest(): void
+    {
+        $reflection = new ReflectionClass(Request::class);
+
+        foreach ([
+            'query_arr' => [],
+            'raw' => null,
+            'body' => null,
+            'body_error' => null,
+            'params' => [],
+            'headers' => [],
+            'accept_encoding' => null,
+            'content_type' => null,
+        ] as $property => $value) {
+            $this->setStaticProperty(Request::class, $property, $value);
+        }
+
+        $this->setStaticProperty(
+            Request::class,
+            'instance',
+            $reflection->newInstanceWithoutConstructor()
+        );
+    }
+
+    private function setStaticProperty(string $class, string $name, $value): void
+    {
+        $reflection = new ReflectionClass($class);
+        $property = $reflection->getProperty($name);
+        $property->setAccessible(true);
+        $property->setValue(null, $value);
+    }
+
+    private function getStaticProperty(string $class, string $name)
+    {
+        $reflection = new ReflectionClass($class);
+        $property = $reflection->getProperty($name);
+        $property->setAccessible(true);
+        return $property->getValue();
+    }
+
+    private function getProperty(object $object, string $name)
+    {
+        $reflection = new ReflectionClass($object);
+        $property = $reflection->getProperty($name);
+        $property->setAccessible(true);
+        return $property->getValue($object);
+    }
+}

--- a/unit-tests/http-query/http-query-smoke.mjs
+++ b/unit-tests/http-query/http-query-smoke.mjs
@@ -1,0 +1,37 @@
+const url = process.argv[2] ?? process.env.SIMPLEREST_QUERY_URL;
+
+if (!url) {
+  throw new Error(
+    'Provide a QUERY endpoint URL as the first argument or SIMPLEREST_QUERY_URL.'
+  );
+}
+
+const payload = {
+  test: 'http-query-smoke',
+  timestamp: new Date().toISOString()
+};
+
+const response = await fetch(url, {
+  method: 'QUERY',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify(payload)
+});
+
+const responseBody = await response.text();
+
+if (!response.ok) {
+  throw new Error(
+    `QUERY ${url} returned HTTP ${response.status}: ${responseBody}`
+  );
+}
+
+console.log(JSON.stringify({
+  method: 'QUERY',
+  url,
+  status: response.status,
+  acceptQuery: response.headers.get('accept-query'),
+  response: responseBody
+}, null, 2));

--- a/unit-tests/web-router/WebRouterTest.php
+++ b/unit-tests/web-router/WebRouterTest.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../app.php';
  * WebRouter Unit Tests
  *
  * Tests all major features of WebRouter including:
- * - Route registration (GET, POST, PUT, PATCH, DELETE, OPTIONS)
+ * - Route registration (GET, POST, PUT, PATCH, DELETE, OPTIONS, QUERY)
  * - Route groups (simple and nested)
  * - Dynamic parameters
  * - Parameter validation with where()
@@ -320,7 +320,7 @@ class WebRouterTest extends TestCase
         $routes = $routesProperty->getValue();
 
         // Should be registered for all HTTP verbs
-        $verbs = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+        $verbs = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'QUERY'];
         foreach ($verbs as $verb) {
             $this->assertArrayHasKey($verb, $routes);
             $this->assertArrayHasKey('unittest-all-verbs', $routes[$verb]);
@@ -508,7 +508,7 @@ class WebRouterTest extends TestCase
         $this->assertArrayHasKey('unittest-mixed-post', $routes['POST']);
 
         // unittest-mixed-all should be in all verbs
-        $verbs = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+        $verbs = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'QUERY'];
         foreach ($verbs as $verb) {
             $this->assertArrayHasKey('unittest-mixed-all', $routes[$verb]);
         }


### PR DESCRIPTION
## Qué cambia

- agrega `WebRouter::query()` y centraliza el registro de verbos;
- incorpora `QUERY` en `any()`, `match()` y `fromArray()`;
- normaliza método, headers y media types en `Request`;
- valida cuerpos JSON de QUERY según RFC 10008 (400/415/422);
- procesa CORS antes del dispatch, incluye QUERY/HEAD en wildcard y corrige el matching de `api/*`;
- agrega QUERY a `ApiClient`;
- corrige los callables ACL de POST y PATCH en `ApiController`;
- documenta el plan para endpoints automáticos de `ApiController` y capacidades HTTP avanzadas.

## Causa raíz

El router y CORS mantenían listas de verbos duplicadas, Request dependía del casing y del formato exacto de Content-Type, y la lectura del body JSON no estaba preparada de forma uniforme para métodos nuevos. Además, los preflight OPTIONS se procesaban demasiado tarde.

## Pruebas

- nueva suite PHPUnit aislada: `composer test:http-query`;
- smoke de transporte Node.js: `npm run test:http-query:smoke -- <url>`;
- workflow obligatorio en PHP 8.1, 8.2 y 8.3;
- validación local de sintaxis PHP/JSON/XML/YAML y `git diff --check`;
- smoke Node real: método QUERY, body JSON y respuesta 200 verificados.

> PHPUnit no pudo ejecutarse en el entorno local porque no incluye un binario PHP; el workflow del PR ejecuta la suite enfocada.